### PR TITLE
Declare types and use mypy strict mode

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+strict = True
+
+[mypy-pulp]
+ignore_missing_imports = True

--- a/optiframe/__init__.py
+++ b/optiframe/__init__.py
@@ -2,3 +2,5 @@ from optiframe.workflow_engine import Task, StepData
 from optiframe.framework import Optimizer
 from optiframe.framework.errors import InfeasibleError
 from optiframe.framework.tasks import SolutionObjValue
+
+__all__ = ["Task", "StepData", "Optimizer", "InfeasibleError", "SolutionObjValue"]

--- a/optiframe/framework/__init__.py
+++ b/optiframe/framework/__init__.py
@@ -5,3 +5,11 @@ from .optimizer import (
     BuiltOptimizer,
     OptimizationPackage,
 )
+
+__all__ = [
+    "Optimizer",
+    "ValidatedOptimizer",
+    "InitializedOptimizer",
+    "BuiltOptimizer",
+    "OptimizationPackage",
+]

--- a/optiframe/framework/errors.py
+++ b/optiframe/framework/errors.py
@@ -1,3 +1,3 @@
 class InfeasibleError(RuntimeError):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("The optimization problem does not have a solution")

--- a/optiframe/framework/optimizer.py
+++ b/optiframe/framework/optimizer.py
@@ -4,7 +4,7 @@ import tempfile
 from dataclasses import dataclass
 from typing import Optional, Self, Type, Any
 
-from pulp import LpProblem, LpMinimize, LpMaximize  # type: ignore
+from pulp import LpProblem, LpMinimize, LpMaximize
 
 from optiframe.workflow_engine import Step, StepData
 from optiframe.workflow_engine.task import Task
@@ -22,9 +22,9 @@ from .tasks import (
 
 @dataclass
 class OptimizationPackage:
-    build_mip: Type[Task]
+    build_mip: Type[Task[Any]]
     validate: Optional[Type[Task[None]]] = None
-    extract_solution: Optional[Type[Task]] = None
+    extract_solution: Optional[Type[Task[Any]]] = None
 
 
 class Optimizer:

--- a/optiframe/framework/tasks.py
+++ b/optiframe/framework/tasks.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Optional
 
-from pulp import LpProblem, LpMinimize, LpAffineExpression, LpStatus, LpMaximize  # type: ignore
+from pulp import LpProblem, LpMinimize, LpAffineExpression, LpStatus, LpMaximize
 
 from optiframe.framework.errors import InfeasibleError
 from optiframe.workflow_engine import Task
@@ -24,7 +24,7 @@ class CreateProblemTask(Task[LpProblem]):
 
 
 class CreateObjectiveTask(Task[LpAffineExpression]):
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
     def execute(self) -> LpAffineExpression:

--- a/optiframe/workflow_engine/__init__.py
+++ b/optiframe/workflow_engine/__init__.py
@@ -1,3 +1,5 @@
 from .task import Task
 from .step import Step, InitializedStep, StepData
 from .workflow import Workflow
+
+__all__ = ["Task", "Step", "InitializedStep", "StepData", "Workflow"]

--- a/optiframe/workflow_engine/step.py
+++ b/optiframe/workflow_engine/step.py
@@ -18,10 +18,10 @@ class TaskDependency:
     param: str
     annotation: Any
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.param}: {self.annotation.__name__}"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.param}: {self.annotation.__name__}"
 
 
@@ -39,13 +39,13 @@ class Step:
     """
 
     name: str
-    tasks: list[Type[Task]]
+    tasks: list[Type[Task[Any]]]
 
     def __init__(self, name: str):
         self.name = name
         self.tasks = []
 
-    def add_task(self, task: Type[Task]) -> Self:
+    def add_task(self, task: Type[Task[Any]]) -> Self:
         """
         Register a task to run in this step.
 
@@ -70,7 +70,7 @@ class InitializedStep:
     def name(self) -> str:
         return self.step.name
 
-    def tasks(self) -> list[Type[Task]]:
+    def tasks(self) -> list[Type[Task[Any]]]:
         return self.step.tasks
 
     def execute(self) -> StepData:
@@ -148,13 +148,13 @@ class InitializedStep:
 
         return self.step_data
 
-    def _task_dependencies(self) -> dict[Type[Task], list[TaskDependency]]:
+    def _task_dependencies(self) -> dict[Type[Task[Any]], list[TaskDependency]]:
         """
         Determine which task depends on which type of data.
 
         :return: For each task, a list of its dependencies.
         """
-        dependencies: dict[Type[Task], list[TaskDependency]] = dict()
+        dependencies: dict[Type[Task[Any]], list[TaskDependency]] = dict()
 
         # Collect the dependencies for each task
         for task in self.tasks():

--- a/optiframe/workflow_engine/workflow.py
+++ b/optiframe/workflow_engine/workflow.py
@@ -15,7 +15,7 @@ class Workflow:
 
     steps: list[Step]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.steps = list()
 
     def add_step(self, step: Step) -> Self:

--- a/poetry.lock
+++ b/poetry.lock
@@ -178,14 +178,14 @@ files = [
 
 [[package]]
 name = "pathspec"
-version = "0.11.0"
+version = "0.11.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pathspec-0.11.0-py3-none-any.whl", hash = "sha256:3a66eb970cbac598f9e5ccb5b2cf58930cd8e3ed86d393d541eaf2d8b1705229"},
-    {file = "pathspec-0.11.0.tar.gz", hash = "sha256:64d338d4e0914e91c1792321e6907b5a593f1ab1851de7fc269557a21b30ebbc"},
+    {file = "pathspec-0.11.1-py3-none-any.whl", hash = "sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"},
+    {file = "pathspec-0.11.1.tar.gz", hash = "sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,6 @@ line-length = 100
 [tool.ruff]
 line-length = 100
 
-[tool.ruff.per-file-ignores]
-"__init__.py" = ["F401"]
-
 [tool.mypy]
 python_version = "3.11"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,6 @@ line-length = 100
 [tool.mypy]
 python_version = "3.11"
 
-[[tool.mypy.overrides]]
-module = "pulp"
-ignore_missing_imports = true
-
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_knapsack.py
+++ b/tests/test_knapsack.py
@@ -115,7 +115,7 @@ OPTIMIZER = Optimizer("test_knapsack", sense=LpMaximize).add_package(
 )
 
 
-def test_one_fitting_item():
+def test_one_fitting_item() -> None:
     """There is only one item, which fits into the knapsack."""
     solution = (
         OPTIMIZER.initialize(
@@ -132,7 +132,7 @@ def test_one_fitting_item():
     assert solution[SolutionData].packed_items == ["apple"]
 
 
-def test_two_items_one_fits():
+def test_two_items_one_fits() -> None:
     """There is only one item, which fits into the knapsack."""
     solution = (
         OPTIMIZER.initialize(


### PR DESCRIPTION
This PR adds the `py.typed` file in the `optiframe` module to signal to users of this library that type annotations are available.

Furthermore, the strict mode for mypy has been enabled and the corresponding type errors fixed.