### PR TITLE
Remove explicit objective creation and injection

### DIFF
--- a/examples/knapsack/base_package.py
+++ b/examples/knapsack/base_package.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from pulp import LpVariable, LpProblem, LpAffineExpression, LpBinary, lpSum
+from pulp import LpVariable, LpProblem, LpBinary, lpSum
 
 from optiframe import Task
 from optiframe.framework import OptimizationPackage
@@ -55,12 +55,10 @@ class BaseMipData:
 class BuildBaseMip(Task[BaseMipData]):
     base_data: BaseData
     problem: LpProblem
-    objective: LpAffineExpression
 
-    def __init__(self, base_data: BaseData, problem: LpProblem, objective: LpAffineExpression):
+    def __init__(self, base_data: BaseData, problem: LpProblem):
         self.base_data = base_data
         self.problem = problem
-        self.objective = objective
 
     def execute(self) -> BaseMipData:
         # Pack the item into the knapsack?
@@ -78,7 +76,7 @@ class BuildBaseMip(Task[BaseMipData]):
         )
 
         # Maximize the profit
-        self.objective += lpSum(
+        self.problem.objective += lpSum(
             self.base_data.profits[item] * var_pack_item[item] for item in self.base_data.items
         )
 

--- a/optiframe/framework/optimizer.py
+++ b/optiframe/framework/optimizer.py
@@ -12,7 +12,6 @@ from optiframe.workflow_engine.workflow import Workflow, InitializedWorkflow
 
 from .tasks import (
     CreateProblemTask,
-    CreateObjectiveTask,
     SolveTask,
     SolveSettings,
     ExtractSolutionObjValueTask,
@@ -50,7 +49,7 @@ class Optimizer:
 
     def initialize(self, *data: Any) -> InitializedOptimizer:
         validate_step = Step("validate")
-        build_mip_step = Step("build_mip").add_task(CreateProblemTask).add_task(CreateObjectiveTask)
+        build_mip_step = Step("build_mip").add_task(CreateProblemTask)
         solve_step = Step("solve").add_task(SolveTask)
         extract_solution_step = Step("extract_solution").add_task(ExtractSolutionObjValueTask)
 

--- a/optiframe/framework/tasks.py
+++ b/optiframe/framework/tasks.py
@@ -21,18 +21,9 @@ class CreateProblemTask(Task[LpProblem]):
 
     def execute(self) -> LpProblem:
         problem = LpProblem(self.problem_settings.name, self.problem_settings.sense)
+        # Initialize the objective to an empty expression
         problem.setObjective(LpAffineExpression())
         return problem
-
-
-class CreateObjectiveTask(Task[LpAffineExpression]):
-    problem: LpProblem
-
-    def __init__(self, problem: LpProblem) -> None:
-        self.problem = problem
-
-    def execute(self) -> LpAffineExpression:
-        return self.problem.objective
 
 
 @dataclass
@@ -49,17 +40,12 @@ class SolveTask(Task[None]):
     def __init__(
         self,
         problem: LpProblem,
-        objective: LpAffineExpression,
         solve_settings: SolveSettings,
     ):
         self.problem = problem
-        self.objective = objective
         self.solve_settings = solve_settings
 
     def execute(self) -> None:
-        # Add objective to MIP
-        self.problem.setObjective(self.objective)
-
         # Solve the problem
         status_code = self.problem.solve(solver=self.solve_settings.solver)
         status = LpStatus[status_code]


### PR DESCRIPTION
Closes #9.

The objective is no longer made available explicitly via `LpAffineExpression` for dependency injection.
Instead it must be accessed via `LpProblem`'s `objective` attribute.