### PR TITLE
Make the model sense a required parameter

### DIFF
--- a/optiframe/framework/optimizer.py
+++ b/optiframe/framework/optimizer.py
@@ -32,7 +32,7 @@ class Optimizer:
     sense: LpMinimize | LpMaximize
     packages: list[OptimizationPackage]
 
-    def __init__(self, name: str, sense: LpMinimize | LpMaximize = LpMinimize):
+    def __init__(self, name: str, sense: LpMinimize | LpMaximize):
         """
         Create a new optimizer.
 


### PR DESCRIPTION
Closes #14.

The default value for the model sense (i.e., minimizing or maximizing the objective) is arbitrary and can reduce unnecessary errors if not specified.

This PR removes the default value and requires that the sense is explicitly specified.