### PR TITLE
Add shorthand .solve() method to InitializedOptimizer

### DIFF
--- a/examples/knapsack/__init__.py
+++ b/examples/knapsack/__init__.py
@@ -14,7 +14,11 @@ from .conflict_package import conflict_package, ConflictData
 
 
 def demo() -> None:
-    """Solve a small instance of the knapsack problem."""
+    """
+    Solve a small instance of the knapsack problem.
+
+    Can be executed via `poetry run knapsack`.
+    """
     item_count = 20
 
     # Generate a problem instance with 20 items
@@ -39,13 +43,7 @@ def demo() -> None:
 
     # Try to solve the problem
     try:
-        solution = (
-            knapsack_optimizer.initialize(base_data, conflict_data)
-            .validate()
-            .pre_processing()
-            .build_mip()
-            .print_mip_and_solve()
-        )
+        solution = knapsack_optimizer.initialize(base_data, conflict_data).solve()
     except InfeasibleError:
         print("Failed to find a solution!")
         exit(1)

--- a/optiframe/framework/optimizer.py
+++ b/optiframe/framework/optimizer.py
@@ -102,9 +102,22 @@ class InitializedOptimizer:
         """
         Execute all optimization steps to solve the problem.
 
-        This is a shorthand for `.validate().pre_processing().build_mip().solve(solver)`.
+        This is a shorthand for
+        `.validate().pre_processing().build_mip().solve(solver)`.
         """
         return self.validate().pre_processing().build_mip().solve(solver)
+
+    def print_mip_and_solve(
+        self,
+        solver: Optional[Any] = None,
+    ) -> StepData:
+        """
+        Execute all optimization steps to solve the problem and print the created MIP.
+
+        This is a shorthand for
+        `.validate().pre_processing().build_mip().print_mip_and_solve(solver)`.
+        """
+        return self.validate().pre_processing().build_mip().print_mip_and_solve(solver)
 
 
 class ValidatedOptimizer:

--- a/optiframe/framework/optimizer.py
+++ b/optiframe/framework/optimizer.py
@@ -95,6 +95,17 @@ class InitializedOptimizer:
 
         return ValidatedOptimizer(self.workflow, validate_time)
 
+    def solve(
+        self,
+        solver: Optional[Any] = None,
+    ) -> StepData:
+        """
+        Execute all optimization steps to solve the problem.
+
+        This is a shorthand for `.validate().pre_processing().build_mip().solve(solver)`.
+        """
+        return self.validate().pre_processing().build_mip().solve(solver)
+
 
 class ValidatedOptimizer:
     workflow: InitializedWorkflow


### PR DESCRIPTION
Closes #23.

Adds `.solve` and `.print_mip_and_solve` convenience methods to the `InitializedOptimizer`.

These are shorthands for `.validate().pre_processing().build_mip().solve(solver)` (or the same with `.print_mip_and_solve(solver)`, if no separate execution of the optimization steps is needed.